### PR TITLE
Fix slow `snapper list` calls

### DIFF
--- a/bin/snap-sync
+++ b/bin/snap-sync
@@ -305,12 +305,12 @@ declare -a CONT_BACKUP_ARRAY
 i=0
 for x in $selected_configs; do
 
-    if [[ "$(snapper -c "$x" list -t single | awk '/'"subvolid=$selected_subvolid, uuid=$selected_uuid"'/ {cnt++} END {print cnt}')" -gt 1 ]]; then
+    if [[ "$(snapper -c "$x" list --disable-used-space -t single | awk '/'"subvolid=$selected_subvolid, uuid=$selected_uuid"'/ {cnt++} END {print cnt}')" -gt 1 ]]; then
         error "More than one snapper entry found with UUID $selected_uuid subvolid $selected_subvolid for configuration $x. Skipping configuration $x."
         continue
     fi
 
-    if [[ "$(snapper -c "$x" list -t single | awk '/'$name' backup in progress/ {cnt++} END {print cnt}')" -gt 0 ]]; then
+    if [[ "$(snapper -c "$x" list --disable-used-space -t single | awk '/'$name' backup in progress/ {cnt++} END {print cnt}')" -gt 0 ]]; then
         printf "\nNOTE: Previous failed %s backup snapshots found for '%s'.\n" "$name" "$x"
         if [[ $noconfirm == "yes" ]]; then
             printf "'noconfirm' option passed. Failed backups will not be deleted.\n"
@@ -327,7 +327,7 @@ for x in $selected_configs; do
                 fi
             done
             if [[ "$delete_failed" == [Yy]"es" || "$delete_failed" == [Yy] ]]; then
-                snapper -c "$x" delete "$(snapper -c "$x" list | awk '/'$name' backup in progress/ {print $1}')"
+                snapper -c "$x" delete "$(snapper -c "$x" list --disable-used-space | awk '/'$name' backup in progress/ {print $1}')"
             fi
         fi
     fi
@@ -347,7 +347,7 @@ for x in $selected_configs; do
 
     printf "\n"
 
-    old_num=$(snapper -c "$x" list -t single | awk '/'"subvolid=$selected_subvolid, uuid=$selected_uuid"'/ {print $1}')
+    old_num=$(snapper -c "$x" list --disable-used-space -t single | awk '/'"subvolid=$selected_subvolid, uuid=$selected_uuid"'/ {print $1}')
     old_snap=$SUBVOLUME/.snapshots/$old_num/snapshot
 
     OLD_NUM_ARRAY[$i]=$old_num
@@ -360,7 +360,7 @@ for x in $selected_configs; do
         BACKUPDIR="$selected_mnt/$mybackupdir"
         $ssh test -d "$BACKUPDIR" || $ssh btrfs subvolume create "$BACKUPDIR"
     else
-        mybackupdir=$(snapper -c "$x" list -t single | awk -F"|" '/'"subvolid=$selected_subvolid, uuid=$selected_uuid"'/ {print $5}' | awk -F "," '/backupdir/ {print $1}' | awk -F"=" '{print $2}')
+        mybackupdir=$(snapper -c "$x" list --disable-used-space -t single | awk -F"|" '/'"subvolid=$selected_subvolid, uuid=$selected_uuid"'/ {print $5}' | awk -F "," '/backupdir/ {print $1}' | awk -F"=" '{print $2}')
         BACKUPDIR="$selected_mnt/$mybackupdir"
         $ssh test -d "$BACKUPDIR" || die "%s is not a directory on %s.\n" "$BACKUPDIR" "$selected_uuid"
     fi


### PR DESCRIPTION
`snapper list` is slow when qgroups are enabled. This is because by default it lists used space ("management wanted it on by default" 🙄) and triggers a quota rescan at the top of each call to `snapper list`. (see: https://github.com/openSUSE/snapper/issues/629)

This adds the `--disable-used-space` to every call to `snapper list`, opting out of the used-space display and consequently the quota rescan.
